### PR TITLE
Slide documentation, Code demo and other Astro components

### DIFF
--- a/src/components/button.astro
+++ b/src/components/button.astro
@@ -1,0 +1,10 @@
+---
+const { className, ...props } = Astro.props
+import cx from 'classnames'
+---
+<button
+  class={cx(className, 'block bg-yellow-500 text-white p-2 rounded')}
+  {...props}
+>
+  <slot />
+</button>

--- a/src/components/code-demo.astro
+++ b/src/components/code-demo.astro
@@ -1,0 +1,190 @@
+---
+import cx from 'classnames'
+const { heading, className } = Astro.props
+const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
+---
+<div class={className}>
+  {heading ? (
+    <h2 
+      id={headingSlug}
+      class="font-semibold tracking-wide text-2xl"
+    >
+      {heading}
+    </h2>
+  ) : null}
+  <div
+    class="rounded-lg relative h-[350px] mt-5 overflow-hidden"
+    data-controller="tabs clipboard"
+    data-clipboard-toggle-success-class="opacity-0 invisible translate-y-2"
+  >
+    <div class="flex absolute top-1 right-2 p-3 backdrop-blur-sm">
+      <ul
+        class="flex space-x-1 pr-1 mr-[6px] relative after:absolute after:inset-y-0 after:left-full after:w-[2px] after:bg-black after:bg-opacity-20 after:scale-y-75"
+        data-action="keyup->tabs#cycleTabs"
+        role="tablist"
+      >
+        {['Preview', 'Code'].map((text, i) => (
+          <li>
+            <button
+              data-tabs-target="tab"
+              data-action="tabs#selectTab"
+              class={cx(
+                'py-2 px-3 text-xs tracking-wide font-semibold rounded',
+                'hover:bg-white hover:bg-opacity-10',
+                'aria-selected:bg-white aria-selected:bg-opacity-20'
+              )}
+              aria-selected={i === 0 ? 'true' : null}
+              tabindex={i !== 0 ? '-1' : null}
+            >
+              {text}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button
+        class="py-2 px-3 text-xs tracking-wide font-semibold rounded relative hover:bg-white hover:bg-opacity-10"
+        data-action="clipboard#copy"
+      >
+        <span class="duration-100" data-clipboard-target="ctaText">Copy</span>
+        <span
+          class="opacity-0 invisible duration-100 translate-y-2 absolute inset-0 flex items-center justify-center"
+          data-clipboard-target="successText"
+        >
+          Copied!
+        </span>
+      </button>
+    </div>
+
+    <div
+      class="rounded-lg p-8 pt-20 bg-gradient-to-r from-indigo-500 to-violet-500 text-slate-300 h-full overflow-auto"
+      data-tabs-target="panel"
+      role="tabpanel"
+    >
+      <slot name="preview" />
+    </div>
+    <div
+      class="rounded-lg p-8 bg-slate-800 ring-2 ring-slate-700 ring-inset text-slate-300 h-full overflow-auto"
+      data-tabs-target="panel"
+      data-clipboard-target="source"
+      role="tabpanel"
+      hidden
+    >
+      <slot name="code" />
+    </div>
+  </div>
+</div>
+
+<style global>
+  code[class*="language-"],
+  pre[class*="language-"] {
+    /* background: none; */
+    color: #f8f8f2;
+    font-family: 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    font-size: 14px;
+    hyphens: none;
+    line-height: 1.5;
+    tab-size: 4;
+    text-align: left;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+    white-space: pre;
+    word-break: normal;
+    word-spacing: normal;
+    word-wrap: normal;
+  }
+
+  /* Inline code */
+  :not(pre) > code[class*="language-"] {
+    padding: .1em;
+    border-radius: .3em;
+    white-space: normal;
+  }
+
+
+  :not(pre) > code[class*="language-"],
+  pre[class*="language-"] {
+    /* background: theme('colors.slate.800'); */
+  }
+
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #6272a4;
+  }
+
+  .token.punctuation {
+    /* color: #f8f8f2; */
+    color: theme('colors.yellow.300');
+    color: theme('colors.cyan.200');
+  }
+
+  .namespace {
+    opacity: .7;
+  }
+
+  .token.property,
+  .token.tag,
+  .token.constant,
+  .token.symbol,
+  .token.deleted {
+    /* color: #ff79c6; */
+    color: theme('colors.pink.500');
+    color: theme('colors.red.400');
+  }
+
+  .token.boolean,
+  .token.number {
+    color: #bd93f9;
+  }
+
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.builtin,
+  .token.inserted {
+    /* color: #50fa7b; */
+    color: theme('colors.emerald.400');
+    color: theme('colors.violet.400');
+  }
+
+  .token.operator,
+  .token.entity,
+  .token.url,
+  .language-css .token.string,
+  .style .token.string,
+  .token.variable {
+    color: #f8f8f2;
+  }
+
+  .token.atrule,
+  .token.attr-value,
+  .token.function,
+  .token.class-name {
+    /* color: #f1fa8c; */
+    color: theme('colors.yellow.500');
+    color: theme('colors.lime.400');
+  }
+
+  .token.keyword {
+    color: #8be9fd;
+  }
+
+  .token.regex,
+  .token.important {
+    color: #ffb86c;
+  }
+
+  .token.important,
+  .token.bold {
+    font-weight: bold;
+  }
+
+  .token.italic {
+    font-style: italic;
+  }
+
+  .token.entity {
+    cursor: help;
+  }
+</style>

--- a/src/components/code-demo.astro
+++ b/src/components/code-demo.astro
@@ -5,12 +5,12 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
 ---
 <div class={className}>
   {heading ? (
-    <h2 
+    <h3
       id={headingSlug}
       class="font-semibold tracking-wide text-2xl"
     >
       {heading}
-    </h2>
+    </h3>
   ) : null}
   <div
     class="rounded-lg relative h-[350px] mt-5 overflow-hidden"
@@ -77,7 +77,6 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
 <style global>
   code[class*="language-"],
   pre[class*="language-"] {
-    /* background: none; */
     color: #f8f8f2;
     font-family: 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
     font-size: 14px;
@@ -102,7 +101,6 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
 
   :not(pre) > code[class*="language-"],
   pre[class*="language-"] {
-    /* background: theme('colors.slate.800'); */
   }
 
   .token.comment,
@@ -113,7 +111,6 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
   }
 
   .token.punctuation {
-    /* color: #f8f8f2; */
     color: theme('colors.yellow.300');
     color: theme('colors.cyan.200');
   }
@@ -127,7 +124,6 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
   .token.constant,
   .token.symbol,
   .token.deleted {
-    /* color: #ff79c6; */
     color: theme('colors.pink.500');
     color: theme('colors.red.400');
   }
@@ -143,7 +139,6 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
   .token.char,
   .token.builtin,
   .token.inserted {
-    /* color: #50fa7b; */
     color: theme('colors.emerald.400');
     color: theme('colors.violet.400');
   }
@@ -161,7 +156,6 @@ const headingSlug = heading.replace(/\s+/g, '-').toLowerCase()
   .token.attr-value,
   .token.function,
   .token.class-name {
-    /* color: #f1fa8c; */
     color: theme('colors.yellow.500');
     color: theme('colors.lime.400');
   }

--- a/src/components/icons/arrow.astro
+++ b/src/components/icons/arrow.astro
@@ -1,0 +1,17 @@
+---
+const { className } = Astro.props
+---
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  class={className}
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke="currentColor"
+>
+  <path
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  stroke-width="2"
+  d="M17 13l-5 5m0 0l-5-5m5 5V6"
+  />
+</svg>

--- a/src/components/icons/lightbulb.astro
+++ b/src/components/icons/lightbulb.astro
@@ -1,0 +1,12 @@
+---
+const { className } = Astro.props
+---
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  class={className}
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke="currentColor"
+>
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+</svg>

--- a/src/components/tip.astro
+++ b/src/components/tip.astro
@@ -1,0 +1,12 @@
+---
+import LightbulbIcon from './icons/lightbulb.astro'
+---
+<div class="border-2 border-yellow-500 bg-slate-800 rounded p-4">
+  <div class="flex items-start text-yellow-500 ">
+    <LightbulbIcon className="w-6 h-6 flex-shrink-0" />
+    <div class="ml-4">
+      <span class="font-semibold">Tip:</span>
+      <slot />
+    </div>
+  </div>
+</div>

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/data/nav.js
+++ b/src/data/nav.js
@@ -1,0 +1,6 @@
+export default [
+  {
+    name: 'Slide',
+    url: 'slide',
+  },
+]

--- a/src/js/controllers/clipboard_controller.js
+++ b/src/js/controllers/clipboard_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['source', 'ctaText', 'successText']
+  static classes = ['toggleSuccess']
+  static values = {
+    successDelay: {
+      default: 1000,
+      type: Number,
+    },
+  }
+
+  successTimeout = null
+
+  copy() {
+    if (this.hasSourceTarget) {
+      /**
+       * Copy the text
+       */
+      const textToCopy = this.sourceTarget.value ?? this.sourceTarget.innerText
+      navigator.clipboard.writeText(textToCopy)
+
+      /**
+       * If ctaText and successText targets exist, flash success message
+       */
+      if (this.hasCtaTextTarget && this.hasSuccessTextTarget) {
+        const classes = this.hasToggleSuccessClass
+          ? this.toggleSuccessClasses
+          : ['opacity-0', 'invisible']
+
+        this.ctaTextTarget.classList.add(...classes)
+        this.successTextTarget.classList.remove(...classes)
+
+        clearTimeout(this.successTimeout)
+        this.successTimeout = setTimeout(() => {
+          this.ctaTextTarget.classList.remove(...classes)
+          this.successTextTarget.classList.add(...classes)
+          this.dispatch('success-dismissed')
+        }, this.successDelayValue)
+      } else {
+        /**
+         * Still emit success-dismissed event for other usage
+         */
+        clearTimeout(this.successTimeout)
+        this.successTimeout = setTimeout(() => {
+          this.dispatch('success-dismissed')
+        }, this.successDelayValue)
+      }
+
+      this.dispatch('copy')
+    }
+  }
+}

--- a/src/js/controllers/clipboard_controller.js
+++ b/src/js/controllers/clipboard_controller.js
@@ -13,41 +13,43 @@ export default class extends Controller {
   successTimeout = null
 
   copy() {
-    if (this.hasSourceTarget) {
-      /**
-       * Copy the text
-       */
-      const textToCopy = this.sourceTarget.value ?? this.sourceTarget.innerText
-      navigator.clipboard.writeText(textToCopy)
-
-      /**
-       * If ctaText and successText targets exist, flash success message
-       */
-      if (this.hasCtaTextTarget && this.hasSuccessTextTarget) {
-        const classes = this.hasToggleSuccessClass
-          ? this.toggleSuccessClasses
-          : ['opacity-0', 'invisible']
-
-        this.ctaTextTarget.classList.add(...classes)
-        this.successTextTarget.classList.remove(...classes)
-
-        clearTimeout(this.successTimeout)
-        this.successTimeout = setTimeout(() => {
-          this.ctaTextTarget.classList.remove(...classes)
-          this.successTextTarget.classList.add(...classes)
-          this.dispatch('success-dismissed')
-        }, this.successDelayValue)
-      } else {
-        /**
-         * Still emit success-dismissed event for other usage
-         */
-        clearTimeout(this.successTimeout)
-        this.successTimeout = setTimeout(() => {
-          this.dispatch('success-dismissed')
-        }, this.successDelayValue)
-      }
-
-      this.dispatch('copy')
+    if (!this.hasSourceTarget) {
+      return
     }
+
+    /**
+     * Copy the text
+     */
+    const textToCopy = this.sourceTarget.value ?? this.sourceTarget.innerText
+    navigator.clipboard.writeText(textToCopy)
+
+    /**
+     * If ctaText and successText targets exist, flash success message
+     */
+    if (this.hasCtaTextTarget && this.hasSuccessTextTarget) {
+      const classes = this.hasToggleSuccessClass
+        ? this.toggleSuccessClasses
+        : ['opacity-0', 'invisible']
+
+      this.ctaTextTarget.classList.add(...classes)
+      this.successTextTarget.classList.remove(...classes)
+
+      clearTimeout(this.successTimeout)
+      this.successTimeout = setTimeout(() => {
+        this.ctaTextTarget.classList.remove(...classes)
+        this.successTextTarget.classList.add(...classes)
+        this.dispatch('success-dismissed')
+      }, this.successDelayValue)
+    } else {
+      /**
+       * Still emit success-dismissed event for other usage
+       */
+      clearTimeout(this.successTimeout)
+      this.successTimeout = setTimeout(() => {
+        this.dispatch('success-dismissed')
+      }, this.successDelayValue)
+    }
+
+    this.dispatch('copy')
   }
 }

--- a/src/js/controllers/slide_controller.js
+++ b/src/js/controllers/slide_controller.js
@@ -1,0 +1,73 @@
+import Slide from '../util/slide'
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['toggler', 'receiver']
+  static classes = ['collapsed']
+  static values = {
+    isOpen: Boolean,
+  }
+
+  /**
+   * Lifecycle
+   */
+
+  initialize() {
+    this.slide = new Slide(
+      this.receiverTarget || this.element,
+      this.hasCollapsedClass ? this.collapsedClass : undefined
+    )
+  }
+
+  /**
+   * Value-changed handlers
+   */
+
+  isOpenValueChanged = () => {
+    this.isOpenValue ? this._open() : this._close()
+  }
+
+  /** Public methods */
+
+  toggle = (e) => {
+    this.isOpenValue = !this.isOpenValue
+    e.currentTarget.setAttribute(
+      'aria-expanded',
+      this.isOpenValue ? 'true' : 'false'
+    )
+    this.dispatch('toggle')
+  }
+
+  open = (e) => {
+    this.isOpenValue = true
+    e.currentTarget.setAttribute('aria-expanded', 'true')
+  }
+
+  close = (e) => {
+    this.isOpenValue = false
+    e.currentTarget.setAttribute('aria-expanded', 'false')
+  }
+
+  /**
+   * Private methods
+   */
+
+  _close = () => {
+    if (!this.slide) return
+    this.slide.close()
+    this.togglerTargets.forEach((el) =>
+      el.setAttribute('aria-expanded', 'false')
+    )
+    this.element.removeAttribute('open')
+    this.dispatch('close')
+  }
+
+  _open = () => {
+    this.slide.open()
+    this.togglerTargets.forEach((el) =>
+      el.setAttribute('aria-expanded', 'true')
+    )
+    this.element.setAttribute('open', 'true')
+    this.dispatch('open')
+  }
+}

--- a/src/js/controllers/slide_controller.js
+++ b/src/js/controllers/slide_controller.js
@@ -13,10 +13,10 @@ export default class extends Controller {
    */
 
   initialize() {
-    this.slide = new Slide(
-      this.receiverTarget || this.element,
-      this.hasCollapsedClass ? this.collapsedClass : undefined
-    )
+    this.slide = new Slide({
+      el: this.receiverTarget || this.element,
+      collapsedClass: this.hasCollapsedClass ? this.collapsedClass : undefined,
+    })
   }
 
   /**

--- a/src/js/controllers/tabs_controller.js
+++ b/src/js/controllers/tabs_controller.js
@@ -1,0 +1,126 @@
+import { Controller } from '@hotwired/stimulus'
+import { normalizeKeyCode } from '../util/key-codes'
+import { wrap } from '../util/wrap'
+
+export default class extends Controller {
+  static targets = ['tablist', 'tab', 'panel']
+
+  static values = {
+    index: Number,
+    disabledMq: String, // this must be a valid media query
+    isDisabled: Boolean, // toggled by a media query listener
+  }
+
+  currentTab = {
+    tab: null,
+    panel: null,
+  }
+
+  /**
+   * Lifecycle
+   */
+
+  initialize() {
+    this.mq = this.hasDisabledMqValue
+      ? window.matchMedia(`${this.disabledMqValue}`)
+      : null
+
+    if (this.mq) {
+      this._handleMqChange(this.mq)
+    }
+  }
+
+  connect() {
+    this.currentTab = {
+      tab: this.tabTargets[this.indexValue],
+      panel: this.panelTargets[this.indexValue],
+    }
+
+    if (this.mq) {
+      this.mq.addEventListener('change', this._handleMqChange)
+    }
+  }
+
+  disconnect() {
+    if (this.mq) {
+      this.mq.removeEventListener('change', this._handleMqChange)
+    }
+  }
+
+  /**
+   * Value-changed handlers
+   */
+
+  isDisabledValueChanged() {
+    if (this.isDisabledValue) {
+      if (this.hasTablistTarget) {
+        this.tablistTarget.setAttribute('hidden', true)
+      }
+
+      this.panelTargets.forEach((panel) => {
+        panel.removeAttribute('hidden')
+        panel.removeAttribute('role')
+      })
+    } else {
+      if (this.hasTablistTarget) {
+        this.tablistTarget.removeAttribute('hidden')
+      }
+
+      this.panelTargets.forEach((panel, i) => {
+        panel.setAttribute('role', 'tabpanel')
+        this.indexValue === i
+          ? panel.removeAttribute('hidden')
+          : panel.setAttribute('hidden', true)
+      })
+    }
+  }
+
+  indexValueChanged() {
+    const { tab: prevTab, panel: prevPanel } = this.currentTab
+    if (!prevTab || !prevPanel) {
+      return
+    }
+
+    prevTab.removeAttribute('aria-selected')
+    prevTab.setAttribute('tabindex', -1)
+    prevPanel.setAttribute('hidden', true)
+
+    const tab = this.tabTargets[this.indexValue]
+    const panel = this.panelTargets[this.indexValue]
+
+    document.activeElement !== tab && tab.focus()
+
+    tab.setAttribute('aria-selected', 'true')
+    tab.removeAttribute('tabindex')
+    panel.removeAttribute('hidden')
+
+    this.currentTab = {
+      tab,
+      panel,
+    }
+  }
+
+  /**
+   * Public methods
+   */
+
+  selectTab = (e) => {
+    this.indexValue = this.tabTargets.indexOf(e.currentTarget)
+  }
+
+  cycleTabs = (e) => {
+    const key = normalizeKeyCode(e)
+
+    if (!['ArrowRight', 'ArrowLeft'].includes(key)) return
+
+    this.indexValue = wrap(
+      key === 'ArrowRight' ? this.indexValue + 1 : this.indexValue - 1,
+      this.panelTargets.length
+    )
+  }
+
+  /**
+   * Private methods
+   */
+  _handleMqChange = ({ matches }) => (this.isDisabledValue = matches)
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,13 @@
+import { Application } from '@hotwired/stimulus'
+
+import SlideController from './controllers/slide_controller'
+import ClassListController from './controllers/class-list_controller'
+import TabsController from './controllers/tabs_controller'
+import ClipboardController from './controllers/clipboard_controller'
+
+window.Stimulus = Application.start()
+Stimulus.register('slide', SlideController)
+Stimulus.register('class-list', ClassListController)
+Stimulus.register('tabs', TabsController)
+Stimulus.register('clipboard', ClipboardController)
+Stimulus.debug = true

--- a/src/js/util/key-codes.js
+++ b/src/js/util/key-codes.js
@@ -1,0 +1,23 @@
+const keyCodes = {
+  13: 'Enter',
+  32: 'Space',
+  9: 'Tab',
+  27: 'Escape',
+  40: 'ArrowDown',
+  37: 'ArrowLeft',
+  39: 'ArrowRight',
+  38: 'ArrowUp',
+}
+
+/**
+* Noramlize code & keyCode for keyboard events
+* @param {object} event
+* @return {?string}
+*/
+export const normalizeKeyCode = ({ code, keyCode }) => {
+  if (code !== undefined) return code
+
+  if (keyCode !== undefined) return keyCodes[keyCode] ?? null
+
+  return null
+}

--- a/src/js/util/slide.js
+++ b/src/js/util/slide.js
@@ -1,5 +1,5 @@
 export default class Slide {
-  constructor(el, collapsedClass = 'collapsed') {
+  constructor({ el, collapsedClass = 'collapsed' }) {
     this.el = el
     this.collapsedClass = collapsedClass
   }

--- a/src/js/util/slide.js
+++ b/src/js/util/slide.js
@@ -1,0 +1,39 @@
+export default class Slide {
+  constructor(el, collapsedClass = 'collapsed') {
+    this.el = el
+    this.collapsedClass = collapsedClass
+  }
+
+  toggle() {
+    this.change('toggle')
+  }
+
+  open() {
+    this.change('remove')
+  }
+
+  close() {
+    this.change('add')
+  }
+
+  change(method) {
+    this.el.addEventListener('transitionend', this.resetHeight, false)
+    this.el.style.maxHeight = this.el.scrollHeight + 'px'
+    this.el.style.overflow = 'hidden'
+
+    // Wait a tick so height has applied
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.el.classList[method](this.collapsedClass)
+      })
+    })
+  }
+
+  resetHeight = (e) => {
+    if (e.target === this.el) {
+      this.el.style.overflow = ''
+      this.el.style.maxHeight = 'none'
+      this.el.removeEventListener('transitionend', this.resetHeight, false)
+    }
+  }
+}

--- a/src/js/util/wrap.js
+++ b/src/js/util/wrap.js
@@ -1,0 +1,7 @@
+/**
+ * Get the wrapped version of an index based on a certain length
+ * @param {Number} i
+ * @param {Number} len
+ * @returns
+ */
+ export const wrap = (i, len) => ((i % len) + len) % len

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -1,0 +1,20 @@
+---
+const {title} = Astro.props
+const isProd = import.meta.env.MODE === 'asdf'
+---
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width">
+  <title>{title}</title>
+  
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="stylesheet" type="text/css" href={`${isProd ? '../' : ''}${Astro.resolve('../css/global.css')}`}>
+  <script type="module" src={Astro.resolve('../js/index.js')}></script>
+</head>
+<body>
+  <main>
+    <slot />
+  </main>
+</body>
+</html>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -1,6 +1,5 @@
 ---
 const {title} = Astro.props
-const isProd = import.meta.env.MODE === 'asdf'
 ---
 <html lang="en">
 <head>
@@ -9,7 +8,7 @@ const isProd = import.meta.env.MODE === 'asdf'
   <title>{title}</title>
   
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-  <link rel="stylesheet" type="text/css" href={`${isProd ? '../' : ''}${Astro.resolve('../css/global.css')}`}>
+  <link rel="stylesheet" type="text/css" href={Astro.resolve('../css/global.css')}>
   <script type="module" src={Astro.resolve('../js/index.js')}></script>
 </head>
 <body>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -5,7 +5,7 @@ const {title} = Astro.props
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
-  <title>{title}</title>
+  <title>{title} | Viget Stimulus Controllers</title>
   
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="stylesheet" type="text/css" href={Astro.resolve('../css/global.css')}>

--- a/src/layouts/documentation.astro
+++ b/src/layouts/documentation.astro
@@ -1,0 +1,58 @@
+---
+import cx from 'classnames'
+import BaseLayout from '../layouts/base-layout.astro'
+import navData from '../data/nav.js'
+const { title } = Astro.props
+const { demos } = Astro.slots
+---
+<BaseLayout>
+  <div class="bg-slate-900 text-slate-300 min-h-screen">
+    <div
+      class="h-2 bg-gradient-to-r from-indigo-500 via-indigo-800 to-purple-500"
+    ></div>
+
+    <div class="flex justify-center">
+      <nav class="w-48 mt-40 pr-12 text-white text-opacity-50">
+        <h2 class="font-semibold uppercase text-sm tracking-wide">Controllers</h2>
+        <ul class="mt-4">
+          {navData.map((item) => (
+            <li>
+              <a
+                href={`../${item.url}`}
+                class={cx(
+                  'block py-1 pl-3 border-l-2',
+                  {
+                    'border-white border-opacity-20 hover:bg-white hover:bg-opacity-5 hover:border-indigo-500 hover:border-opacity-100': item.name !== title,
+                    'text-white text-opacity-100 border-indigo-500': item.name === title,
+                  }
+                )}
+              >
+                {item.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div class="flex-grow max-w-3xl py-20 px-5">
+        <h1 class="text-7xl text-indigo-400 font-extrabold relative">
+          <span class="opacity-20 absolute -left-7 bottom-0 text-9xl overflow-hidden">
+            {title}
+            <span class="absolute inset-0 bg-gradient-to-t from-slate-900"></span>
+          </span>
+          {title}
+        </h1>
+        <div class="prose mt-8">
+          <slot name="api" />
+        </div>
+        {demos ? (
+          <div class="prose mt-12">
+            <h2>Demos</h2>
+          </div>
+        ) : null}
+        <div class="divide-y-2 divide-slate-400">
+          <slot name="demos" />
+        </div>
+      </div>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/layouts/documentation.astro
+++ b/src/layouts/documentation.astro
@@ -5,15 +5,15 @@ import navData from '../data/nav.js'
 const { title } = Astro.props
 const { demos } = Astro.slots
 ---
-<BaseLayout>
+<BaseLayout title={title}>
   <div class="bg-slate-900 text-slate-300 min-h-screen">
     <div
       class="h-2 bg-gradient-to-r from-indigo-500 via-indigo-800 to-purple-500"
     ></div>
 
     <div class="flex justify-center">
-      <nav class="w-48 mt-40 pr-12 text-white text-opacity-50">
-        <h2 class="font-semibold uppercase text-sm tracking-wide">Controllers</h2>
+      <nav class="w-48 mt-40 pr-12 text-white text-opacity-50" aria-label="Site Navigation">
+        <p class="font-semibold uppercase text-sm tracking-wide">Controllers</p>
         <ul class="mt-4">
           {navData.map((item) => (
             <li>
@@ -35,7 +35,7 @@ const { demos } = Astro.slots
       </nav>
       <div class="flex-grow max-w-3xl py-20 px-5">
         <h1 class="text-7xl text-indigo-400 font-extrabold relative">
-          <span class="opacity-20 absolute -left-7 bottom-0 text-9xl overflow-hidden">
+          <span class="opacity-20 absolute -left-7 bottom-0 text-9xl overflow-hidden" aria-hidden="true">
             {title}
             <span class="absolute inset-0 bg-gradient-to-t from-slate-900"></span>
           </span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import DocumentationLayout from '../layouts/documentation.astro'
+import { Markdown } from 'astro/components'
+---
+<DocumentationLayout title="Home">
+  <section slot="api">
+    <Markdown>
+      ## TODO
+    </Markdown>
+  </section>
+</DocumentationLayout>

--- a/src/pages/slide.astro
+++ b/src/pages/slide.astro
@@ -1,0 +1,376 @@
+---
+import DocumentationLayout from '../layouts/documentation.astro'
+import { Markdown } from 'astro/components'
+import Button from '../components/button.astro'
+import ArrowIcon from '../components/icons/arrow.astro'
+import CodeDemo from '../components/code-demo.astro'
+
+const accordionItems = [
+  {
+    heading: 'this is a heading',
+    text: 'this is the description that you had to expand!'
+  },
+  {
+    heading: 'this is another heading',
+    text: 'asdf asdfasdf this is the description that you had to expand!'
+  },
+  {
+    heading: 'asdfasdfasdfasdfa this is another heading',
+    text: 'qwerqwe this is the description that you had to expand!'
+  },
+]
+---
+<DocumentationLayout title="Slide">
+  <section slot="api">
+    <Markdown>
+      ## Install
+
+      ```js
+      // index.js
+      import SlideController from '@viget/stimulus-controllers/slide_controller'
+      Stimulus.register('slide', SlideController)
+      ```
+
+      ## Values 
+
+      | Value | Full Attribute | Type | Default | Description |
+      |:---|:---|:---|:---|:---|
+      | `isOpen` | `data-slide-is-open-value` | Boolean | `false` |  Controls whether the `receiver` is expanded or collapsed |
+
+      ## Targets
+
+      | Target | Full Attribute | Description | Required |
+      |:---|:---|:---|:---|
+      | `toggler` | `data-slide-target="toggler"` | Add to the elements using `toggle`, `open`, or `close`. This should only be used if there are multiple elements with `aria-expanded` that need to be synced; otherwise the element is grabbed from the event. | No |
+      | `receiver` | `data-slide-target="receiver"` | Add to the element that is being toggled/opened/closed. This is used in almost all patterns, but if not set it will default to the toggler element. | No |
+
+      ## Classes
+
+      | Class | Full Attribute | Description |
+      |:---|:---|:---|
+      | `collapsed` | `data-slide-collapsed-class` | This defaults to `collapsed`. Use cases for overriding might be a responsive version (e.g. `sm:collapsed`), a different animation, or a different `min-height`. See [CSS](#css) for more information. |
+
+      ## Actions
+
+      ### `toggle()`
+      _Event: `slide:toggle`_
+
+      Slides `receiver` target open or closed by toggling `isOpen` value
+
+      ---
+
+      ### `open()`
+      _Event: `slide:open`_
+
+      Opens `receiver` target by setting `isOpen` value to `true`
+
+      ---
+
+      ### `close()`
+      _Event: `slide:close`_
+
+      Closes `receiver` target by setting `isOpen` value to `false`
+
+      ## Dependencies
+
+      ### CSS
+
+      The sliding collapse/expand leverages CSS transitions, so some styles are required. The following Tailwind plugin provides the `collapsed` class expected by default, as well specifies the properties we'll be transitioning. The `receiver` target still needs to specify a `transition-duration`, e.g using the `duration-` utilities.
+
+      Using the plugin also makes it possible to combine the class with screens, such as `smd:collapsed` in the [example below](#only-collapse-on-mobile).
+
+      ```js
+      const plugin = require('tailwindcss/plugin')
+
+      module.exports = plugin(({ addUtilities, variants }) => {
+        const pluginVariants = variants('collapsed', [])
+
+        const collapsed = {
+          '[data-slide-target="receiver"]': {
+            opacity: 1,
+            transitionProperty: 'opacity, visibility, max-height',
+            visibility: 'visible',
+          },
+
+          '.collapsed': {
+            'max-height': '0 !important',
+            opacity: 0,
+            overflow: 'hidden',
+            visibility: 'hidden',
+          },
+        }
+
+        addUtilities(collapsed, pluginVariants)
+      })
+      ```
+    </Markdown>
+  </section>
+
+  <section class="divide-y divide-slate-700" slot="demos">
+    <CodeDemo heading="Basic" className="py-8">
+      <div slot="preview">
+        <div data-controller="slide" class="space-y-3 max-w-md mx-auto">
+          <p>Why did the chicken cross the road?</p>
+          <div>
+            <Button
+              data-action="slide#toggle"
+              aria-expanded="false"
+            >
+              Tell me!
+            </Button>
+          </div>
+          <div class="collapsed duration-200" data-slide-target="receiver">
+            <p class="p-3 bg-white bg-opacity-30 drop-shadow-lg text-indigo-800 rounded-lg">
+              To get to the other side.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div slot="code">
+        <Markdown>
+          ```html
+          <div data-controller="slide">
+            <button
+              data-action="slide#toggle"
+              aria-expanded="false"
+            >
+              Why did the chicken cross the road?
+            </button>
+            <p
+              class="collapsed duration-200"
+              data-slide-target="receiver"
+            >
+              To get to the other side.
+            </p>
+          </div>
+          ```
+        </Markdown>
+      </div>
+    </CodeDemo>
+
+    <CodeDemo heading="Accordion" className="py-8">
+      <div slot="preview">
+        <ul class="space-y-3 max-w-md mx-auto">
+          {accordionItems.map(({ heading, text }) => (
+            <li
+              class="group border-2 border-white border-opacity-20 rounded-md"
+              data-controller="slide"
+            >
+              <button
+                class="flex items-center justify-between w-full p-3"
+                  data-action="slide#toggle"
+                  aria-expanded="false"
+              >
+                {heading}
+
+                <span class="block">
+                  <span class="sr-only">Toggle content</span>
+                  <ArrowIcon
+                    className="h-6 w-6 group-open:rotate-180 duration-100"
+                  />
+                </span>
+              </button>
+              <div
+                class="collapsed duration-200"
+                data-slide-target="receiver"
+              >
+                <div class="p-3 pt-0">
+                  <p class="p-3 bg-white bg-opacity-30 drop-shadow-lg text-indigo-800 rounded-lg">
+                    {text}
+                  </p>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div slot="code">
+        <Markdown>
+          ```html
+          <ul>
+            <li
+              class="group"
+              data-controller="slide"
+            >
+              <button
+                class="flex items-center justify-between w-full"
+                data-action="slide#toggle"
+                aria-expanded="false"
+              >
+                Heading/Button Text
+
+                <span class="block">
+                  <span class="sr-only">Toggle content</span>
+                  <ArrowIcon
+                    className="group-open:rotate-180 duration-100"
+                  />
+                </span>
+              </button>
+              <div
+                class="collapsed duration-200"
+                data-slide-target="receiver"
+              >
+                <p class="mt-3">
+                  Expanded text
+                </p>
+              </div>
+            </li>
+          </ul>
+          ```
+        </Markdown>
+      </div>
+    </CodeDemo>
+
+    <CodeDemo heading="Only collapse on mobile" className="py-8">
+      <div slot="preview">
+        <div
+          class="space-y-3 max-w-md mx-auto smd:border-2 smd:border-white smd:border-opacity-20 smd:p-3 smd:rounded-md"
+          data-controller="slide"
+          data-slide-collapsed-class="smd:collapsed"
+        >
+          <div class="flex items-center justify-between w-full">
+            Why did the chicken cross the road?
+
+            <Button
+              className="sm:hidden"
+              data-action="slide#toggle"
+              aria-expanded="false"
+            >
+              <span class="sr-only">Toggle content</span>
+              <ArrowIcon
+                className="h-6 w-6 group-open:rotate-180 duration-100"
+              />
+            </Button>
+          </div>
+          <div
+            class="smd:collapsed duration-200"
+            data-slide-target="receiver"
+          >
+            <p class="p-3 bg-white bg-opacity-30 drop-shadow-lg text-indigo-800 rounded-lg">
+              To get to the other side.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div slot="code">
+        <Markdown>
+          ```html
+          <div
+            data-controller="slide"
+            data-slide-collapsed-class="smd:collapsed"
+          >
+            <div>
+              Why did the chicken cross the road?
+
+              <button
+                class="sm:hidden"
+                data-action="slide#toggle"
+                aria-expanded="false"
+              >
+                Toggle answer
+              </button>
+            </div>
+            <div
+              class="smd:collapsed duration-200"
+              data-slide-target="receiver"
+            >
+              <p>To get to the other side.</p>
+            </div>
+          </div>
+          ```
+        </Markdown>
+      </div>
+    </CodeDemo>
+
+    <CodeDemo heading="Expand once" className="py-8">
+      <div slot="preview">
+        <div data-controller="slide class-list">
+          <div class="p-3 rounded-lg border-2 border-white border-opacity-20">
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit.
+              Voluptate cumque ducimus rem quisquam non sit beatae
+              reprehenderit molestiae odio ab nulla blanditiis voluptas velit
+              dolorem, placeat facilis impedit architecto eveniet.
+            </p>
+            <div
+              class="collapsed duration-200 space-y-4"
+              data-slide-target="receiver"
+            >
+              <p class="mt-4">
+                Lorem ipsum dolor sit amet consectetur adipisicing elit.
+                Libero excepturi reprehenderit, odit quidem cupiditate, eum
+                quis soluta saepe officia ducimus commodi, sapiente nam. Id
+                atque alias odit dolores, quo assumenda!
+              </p>
+              <p>
+                Asperiores nostrum ex obcaecati laboriosam tenetur. Aliquid
+                nesciunt veniam adipisci quis officia suscipit cupiditate
+                numquam corrupti, mollitia consequuntur quisquam velit iure
+                magnam tempora tempore, id facere. Corporis voluptatum
+                expedita optio.
+              </p>
+              <p>
+                Eveniet voluptate iusto beatae nesciunt, tenetur voluptatem,
+                delectus sequi rem voluptatum dolor ratione numquam quod autem
+                aperiam perspiciatis dolorem. Laborum consequatur neque
+                repellat earum voluptate quae et dolorum iste magnam?
+              </p>
+              <p>
+                Illo provident doloribus expedita nemo maxime rerum nisi
+                harum, odio dolores ratione doloremque, omnis necessitatibus
+                voluptates? Voluptas provident consequatur quasi cum aperiam
+                at nulla laudantium harum possimus. Corporis, saepe
+                laudantium!
+              </p>
+              <p>
+                Aut omnis laboriosam quisquam dolorum blanditiis tempore
+                similique ex, impedit vel id odit in nostrum iure, et adipisci
+                minima quae fugit doloremque. Veniam facere sunt
+                exercitationem voluptas alias laudantium neque.
+              </p>
+            </div>
+          </div>
+          <button
+            class="bg-yellow-500 text-white p-2 rounded mt-3"
+            data-class-list-target="receiver"
+            data-action="slide#toggle:once class-list#add"
+            data-class-list-class-param="hidden"
+          >
+            Expand
+          </button>
+        </div>
+      </div>
+      <div slot="code">
+        <Markdown>
+          ```html
+          <div data-controller="slide class-list">
+            <div>
+              <p>
+                Visible to start
+              </p>
+              <div
+                class="collapsed duration-200"
+                data-slide-target="receiver"
+              >
+                <p class="mt-4">
+                  Visible after expanding
+                </p>
+              </div>
+            </div>
+            <button
+              data-class-list-target="receiver"
+              data-action="slide#toggle:once class-list#add"
+              data-class-list-class-param="hidden"
+            >
+              Expand
+            </button>
+          </div>
+          ```
+        </Markdown>
+      </div>
+    </CodeDemo>
+  </section>
+</DocumentationLayout>


### PR DESCRIPTION
This is bigger than the other PRs because the `<CodeDemo>` components makes use of the `tabs` and `clipboard` controllers.

If you're new to Astro, welcome! Everyone is. Astro is a SSG that supports a variety of [renderers](https://github.com/snowpackjs/astro/tree/main/packages/renderers), but this uses the out-of-the-box Astro components.

⚡  Lightning quick intro:
- SFC structure, with `js` going in frontmatter and scoped styles in `<style>` tags. These can be exposed globally via `global` attribute
- JSX-like markup, only a couple (welcome) [differences](https://docs.astro.build/core-concepts/astro-components/#comparing-astro-versus-jsx)
- props are destructured from `Astro.props`
- Compose with `<slot />`s. One `<slot />` is the same as React `children`. To use multiple, you can name them.
- File-based routing -- pages must live in `src/pages`
- Markdown support

And then the documentation pages are built like this:

1. `<BaseLayout>` has HTML boillerplate
2. `<DocumentationLayout>` extends this with
- heading
- nav
- two slots:
  - `<slot name="api" />`
    - written pretty much exclusively using Astro's `<Markdown>` component
  - `<slot name="demos" />`
    - series of `<CodeDemo>` components, which also have two slots:
      - `<slot name="preview">` is the rendered code
      - `<slot name="code">` is the viewable markup

---

🚀  https://code.viget.com/stimulus-controllers/slide/

⚠️ Note, this isn't released so the `install` instructions aren't testable yet!